### PR TITLE
Typo: complementary → complimentary

### DIFF
--- a/app/views/home/benefits.html.erb
+++ b/app/views/home/benefits.html.erb
@@ -4,6 +4,6 @@
 
 <p>Corporate members are also credited during conference talks by Ruby Together developers, and in project release notes, as well as being allowed to request up to 5 Slack invitations.</p>
 
-<p>Every member will receive complementary access to future projects, and each member is given one vote in the yearly election of new Ruby Together board members.</p>
+<p>Every member will receive complimentary access to future projects, and each member is given one vote in the yearly election of new Ruby Together board members.</p>
 
 <p><%= link_to "Join now", join_url %> to support <%= link_to "our work", projects_path %> and start your membership benefits today.</p>


### PR DESCRIPTION
I spotted this just as #1 was merged, d'oh.

I _think_ this is a typo, because "complimentary" feels more right here than the idea of the free access complementing something else. Thought it worth PRing, anyways.