### PR TITLE
Fix newsletter form alignment in Firefox

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -382,22 +382,20 @@ input[type="submit"] {
 }
 
 .inline-field {
-  width: 516px;
   margin: 15px auto;
 
   label {
-    float: left;
-    margin-top: 12px;
-    margin-right: 15px;
+    display: inline-block;
+    margin-top: 10px;
+    margin-right: 10px;
   }
 
   input {
-    float: left;
     margin-right: 0;
   }
 
   input[type="email"] {
-    margin-right: 15px;
+    margin-right: 10px;
   }
 }
 


### PR DESCRIPTION
Greetings!

The newsletter sign up form is looking kind of messy in Firefox:
![screen shot 2015-10-19 at 4 50 37 pm](https://cloud.githubusercontent.com/assets/1153190/10605669/10c23aec-770c-11e5-81da-20c1a5e8dcb2.png)
In this PR I propose some changes in the css to make it looks more similar to the rendered result in Chrome.

Here is the result in Firefox:
![screen shot 2015-10-20 at 9 27 13 am](https://cloud.githubusercontent.com/assets/1153190/10605772/d124df92-770c-11e5-89b7-8edadee9b597.png)

And here is how it looks in Chrome after the changes:
![screen shot 2015-10-20 at 9 30 51 am](https://cloud.githubusercontent.com/assets/1153190/10605861/7a218d48-770d-11e5-8b95-3512036be0f5.png)

Best regards.
