### PR TITLE
Display a membership expiry warning in Slack.

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -7,6 +7,11 @@ class Membership < ActiveRecord::Base
     kinds.flatten.map{|k| Membership.kinds[k] }
   end
 
+  # Find all memberships where the user is on trial, i.e. annual members.
+  def self.on_trial
+    where user_id: User.on_trial.pluck(:id)
+  end
+
   scope :active, -> { where("expires_at > ?", Time.now) }
   scope :named,  -> { where("name IS NOT NULL") }
   scope :since, -> (time) { where("created_at > ?", time) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,19 @@ class User < ActiveRecord::Base
 
   attr_writer :stripe_customer
 
+  # Return users that have a trial subscription, i.e. annual members.
+  def self.on_trial
+    where stripe_id: trial_stripe_subscriptions.map(&:customer)
+  end
+
+  # Finds all subscriptions inside Stripe that have the status 'trialing'.
+  # This is better than Membership#prepaid, but it requires network activity.
+  def self.trial_stripe_subscriptions
+    Stripe::Subscription.list(limit: 50).auto_paging_each.select do |subscription|
+      subscription.status == 'trialing'
+    end
+  end
+
   def generate_reset_password_token!
     set_reset_password_token
   end

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -24,4 +24,27 @@ namespace :stats do
     dollars = ActiveSupport::NumberHelper.number_to_currency(estimate/100)
     puts "Projected monthly income is #{dollars} per month."
   end
+
+  desc "Calculate expiring annual memberships"
+  task :expiring_annual_memberships => [:environment] do |t, args|
+    expiring_memberships = Membership.on_trial.where(
+      "expires_at <= ?", 1.month.from_now
+    ).order("expires_at ASC")
+
+    if expiring_memberships.any?
+      message = "It appears that the following subscriptions are going to expire soon: \n"
+
+      expiring_memberships.each do |membership|
+        message << "*#{membership.name}* "
+        message << "https://dashboard.stripe.com/customers/#{membership.user.stripe_id}\n"
+        message << "Expires at: #{membership.expires_at.strftime("%A, %d %B %Y")}\n\n"
+      end
+
+      Slack.say(message,
+        username: "Expiring Annual Subscribers",
+        channel: "#stripe",
+        icon_emoji: ":chart_with_downwards_trend:"
+      )
+    end
+  end
 end


### PR DESCRIPTION
This applies only to subscriptions that are 'on trial',
which is used to handle "annual members".

This is intended to be used with Heroku scheduler,
and to warn for expirations in the next month.