### PR TITLE
Membership expiry 

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -12,7 +12,7 @@ class HomeController < ApplicationController
       pluck(:name, :description, :url)
     @other_companies = Membership.nonfeatured_companies.named.active.order(:created_at).pluck(:name, :url)
     @individual = Membership.individual.named.active.order(:created_at).pluck(:name)
-    @individual_count = Membership.individual.count
+    @individual_count = Membership.individual.active.count
   end
 
   private

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -13,6 +13,7 @@ class Membership < ActiveRecord::Base
   end
 
   scope :active, -> { where("expires_at > ?", Time.now) }
+  scope :expired, -> { where("expires_at < ?", Time.now) }
   scope :named,  -> { where("name IS NOT NULL") }
   scope :since, -> (time) { where("created_at > ?", time) }
   scope :prepaid, -> { where("expires_at > ?", 1.month.from_now) }

--- a/lib/stripe_event/base.rb
+++ b/lib/stripe_event/base.rb
@@ -3,7 +3,7 @@ module StripeEvent
 
     def user_for_event(event)
       customer = Stripe::Customer.retrieve(event.data.object.customer)
-      return if customer.respond_to?(:deleted) && customer.deleted
+      return nil if customer.respond_to?(:deleted?) && customer.deleted?
 
       event_user = User.includes(:membership).where(stripe_id: customer.id).first
       return nil if event_user.nil?


### PR DESCRIPTION
Fixes:

* Individual member count was not taking into account expired members
* Don't try to mess with users or subscriptions unless we have an invoice object.  This also means that we're not aborting too early just because it can't find a user or subscription when it _should have_.  We are keeping a close eye on this thanks to #42 and #43 so we will see if this causes problems.
* Adds `Membership.expired` scope to easily query for this without remembering how that works.