### PR TITLE
Refactored stats tasks to ruby class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
       activesupport (= 4.2.6)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (11.1.2)
+    rake (11.2.2)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -5,7 +5,12 @@ module Slack
     attr_accessor :team, :notifier
 
     def say(message, options = {})
-      Slack.notifier && Slack.notifier.ping(message, options)
+      if Slack.notifier
+        Slack.notifier.ping(message, options)
+      else
+        puts "== Slack is not configured ==\n\n"
+        puts message
+      end
     end
 
     def invite(email)

--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -1,0 +1,102 @@
+class Stats
+  def initialize(slack: true)
+    @slack = slack
+  end
+
+  def since(last_date)
+    new_members = Membership.since(last_date)
+    groups = new_members.group_by(&:kind)
+    plans = MembershipPlan.all.values.sort_by(&:amount)
+
+    plans.select{|plan| groups[plan.id] }.
+      map{|plan| [plan, groups[plan.id]] }.
+      each do |plan, group|
+        puts "#{group.size} new #{plan.shortname} #{"member".pluralize(group.size)}: #{group.map(&:name).compact.to_sentence}"
+      end
+
+    companies, people = new_members.partition(&:corporate?)
+    message = "\n"
+    message << "#{people.count} new #{"person".pluralize(people.count)}"
+    message << "#{companies.count} new #{"company".pluralize(companies.count)}"
+    message << "#{new_members.size} new #{"member".pluralize(new_members.size)} total"
+    message << "\n"
+    estimate = MonthlyRevenue.projected(
+      MembershipPlan.subscriber_counts,
+      Membership.prepaid
+    )
+    dollars = ActiveSupport::NumberHelper.number_to_currency(estimate/100)
+    message << "Projected monthly income is #{dollars} per month."
+
+    say(message,
+      username: "Memberships Since #{last_data}",
+      channel: "#stripe",
+      icon_emoji: ":chart_with_upwards_trend:"
+    )
+  end
+
+  def expiring_annual_memberships
+    expiring_memberships = Membership.on_trial.where(
+      "expires_at <= ?", 1.month.from_now
+    ).order("expires_at ASC")
+
+    if expiring_memberships.any?
+      message = "It appears that the following subscriptions are going to expire soon: \n"
+
+      expiring_memberships.each do |membership|
+        message << "*#{membership.name}* "
+        message << "https://dashboard.stripe.com/customers/#{membership.user.stripe_id}\n"
+        message << "Expires at: #{membership.expires_at.strftime("%A, %d %B %Y")}\n\n"
+      end
+
+      say(message,
+        username: "Expiring Annual Subscribers",
+        channel: "#stripe",
+        icon_emoji: ":chart_with_downwards_trend:"
+      )
+    end
+  end
+
+  def expired_memberships(expires_at)
+    require 'action_view/helpers'
+    include ActionView::Helpers::DateHelper
+    expiries = Membership.where(
+      "expires_at BETWEEN ? AND ?", expires_at, Time.now
+    ).select { |membership| membership.user.stripe_customer.subscriptions.any? }.map do |member|
+      "#{member.user.email}: #{time_ago_in_words(member.expires_at)}"
+    end
+
+    if expiries.any?
+      say(expiries.join("\n"),
+        username: "Recently Expired Memberships",
+        channel: "#stripe",
+        icon_emoji: ":chart_with_downwards_trend:"
+      )
+    end
+  end
+
+  def monthly_revenue_projection
+    subscriber_counts = MembershipPlan.subscriber_counts
+    message = subscriber_counts.map do |plan, count|
+      "#{count} #{plan.name.pluralize(count)}"
+    end.to_sentence
+    estimate = MonthlyRevenue.projected(subscriber_counts, Membership.prepaid)
+    dollars = ActiveSupport::NumberHelper.number_to_currency(estimate/100)
+    message << ". Projected revenue now #{dollars} per month."
+
+    say(message,
+      username: "Subscribers",
+      channel: "#stripe",
+      icon_emoji: ":chart_with_upwards_trend:"
+    )
+  end
+
+  private
+
+  def say(message, options = {})
+    if @slack
+      Slack.say(message, options)
+    else
+      puts message
+    end
+  end
+end

--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -1,6 +1,6 @@
 class Stats
   def initialize(slack: true)
-    @slack = slack
+    @slack = slack && (Rails.env.test? || Slack.team.present?)
   end
 
   def since(last_date)
@@ -16,9 +16,9 @@ class Stats
 
     companies, people = new_members.partition(&:corporate?)
     message = "\n"
-    message << "#{people.count} new #{"person".pluralize(people.count)}"
-    message << "#{companies.count} new #{"company".pluralize(companies.count)}"
-    message << "#{new_members.size} new #{"member".pluralize(new_members.size)} total"
+    message << "#{people.count} new #{"person".pluralize(people.count)}\n"
+    message << "#{companies.count} new #{"company".pluralize(companies.count)}\n"
+    message << "#{new_members.size} new #{"member".pluralize(new_members.size)} total\n"
     message << "\n"
     estimate = MonthlyRevenue.projected(
       MembershipPlan.subscriber_counts,

--- a/lib/stripe_event/subscription/changed.rb
+++ b/lib/stripe_event/subscription/changed.rb
@@ -6,7 +6,10 @@ module StripeEvent
         user = User.find_by_stripe_id(event.data.object.customer)
         user.try(:membership).try(:update, kind: event.data.object.plan.id)
 
-        Stats.new(slack: true).monthly_revenue_projection
+        Slack.say Stats.monthly_revenue_projection,
+          username: "Subscribers",
+          channel: "#stripe",
+          icon_emoji: ":chart_with_upwards_trend:"
       end
 
     end

--- a/lib/stripe_event/subscription/changed.rb
+++ b/lib/stripe_event/subscription/changed.rb
@@ -6,19 +6,7 @@ module StripeEvent
         user = User.find_by_stripe_id(event.data.object.customer)
         user.try(:membership).try(:update, kind: event.data.object.plan.id)
 
-        subscriber_counts = MembershipPlan.subscriber_counts
-        message = subscriber_counts.map do |plan, count|
-          "#{count} #{plan.name.pluralize(count)}"
-        end.to_sentence
-        estimate = MonthlyRevenue.projected(subscriber_counts, Membership.prepaid)
-        dollars = ActiveSupport::NumberHelper.number_to_currency(estimate/100)
-        message << ". Projected revenue now #{dollars} per month."
-
-        Slack.say(message,
-          username: "Subscribers",
-          channel: "#stripe",
-          icon_emoji: ":chart_with_upwards_trend:"
-        )
+        Stats.new(slack: true).monthly_revenue_projection
       end
 
     end

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -1,69 +1,21 @@
 namespace :stats do
   desc "Calculate monthly stats"
   task :since, [:last_date] => [:environment] do |t, args|
-    new_members = Membership.since(args[:last_date])
-    groups = new_members.group_by(&:kind)
-    plans = MembershipPlan.all.values.sort_by(&:amount)
-
-    plans.select{|plan| groups[plan.id] }.
-      map{|plan| [plan, groups[plan.id]] }.
-      each do |plan, group|
-        puts "#{group.size} new #{plan.shortname} #{"member".pluralize(group.size)}: #{group.map(&:name).compact.to_sentence}"
-      end
-
-    companies, people = new_members.partition(&:corporate?)
-    puts
-    puts "#{people.count} new #{"person".pluralize(people.count)}"
-    puts "#{companies.count} new #{"company".pluralize(companies.count)}"
-    puts "#{new_members.size} new #{"member".pluralize(new_members.size)} total"
-    puts
-    estimate = MonthlyRevenue.projected(
-      MembershipPlan.subscriber_counts,
-      Membership.prepaid
-    )
-    dollars = ActiveSupport::NumberHelper.number_to_currency(estimate/100)
-    puts "Projected monthly income is #{dollars} per month."
+    Stats.new(slack: false).since(args[:last_date])
   end
 
   desc "Post expiring annual memberships to Slack."
   task :expiring_annual_memberships => [:environment] do |t, args|
-    expiring_memberships = Membership.on_trial.where(
-      "expires_at <= ?", 1.month.from_now
-    ).order("expires_at ASC")
-
-    if expiring_memberships.any?
-      message = "It appears that the following subscriptions are going to expire soon: \n"
-
-      expiring_memberships.each do |membership|
-        message << "*#{membership.name}* "
-        message << "https://dashboard.stripe.com/customers/#{membership.user.stripe_id}\n"
-        message << "Expires at: #{membership.expires_at.strftime("%A, %d %B %Y")}\n\n"
-      end
-
-      Slack.say(message,
-        username: "Expiring Annual Subscribers",
-        channel: "#stripe",
-        icon_emoji: ":chart_with_downwards_trend:"
-      )
-    end
+    Stats.new(slack: true).expiring_annual_memberships
   end
 
   desc "Post recently expired memberships (last day by default) to Slack."
   task :expired_memberships, [:expires_at] => [:environment] do |t, args|
-    require 'action_view/helpers'
-    include ActionView::Helpers::DateHelper
-    expiries = Membership.where(
-      "expires_at BETWEEN ? AND ?", expires_at ||= 1.day.ago, Time.now
-    ).select { |membership| membership.user.stripe_customer.subscriptions.any? }.map do |member|
-      "#{member.user.email}: #{time_ago_in_words(member.expires_at)}"
-    end
+    Stats.new(slack: true).expired_memberships(expires_at ||= 1.day.ago)
+  end
 
-    if expiries.any?
-      Slack.say(expiries.join("\n"),
-        username: "Recently Expired Memberships",
-        channel: "#stripe",
-        icon_emoji: ":chart_with_downwards_trend:"
-      )
-    end
+  desc "Post projected monthly revenue to Slack."
+  task :monthly_revenue_projection => [:environment] do
+    Stats.new(slack: true).monthly_revenue_projection
   end
 end

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -1,21 +1,30 @@
 namespace :stats do
   desc "Calculate monthly stats"
   task :since, [:last_date] => [:environment] do |t, args|
-    Stats.new(slack: false).since(args[:last_date])
+    puts Stats.since(args[:last_date])
   end
 
   desc "Post expiring annual memberships to Slack."
   task :expiring_annual_memberships => [:environment] do |t, args|
-    Stats.new(slack: true).expiring_annual_memberships
+    Slack.say Stats.expiring_annual_memberships,
+      username: "Expiring Annual Subscribers",
+      channel: "#stripe",
+      icon_emoji: ":chart_with_downwards_trend:"
   end
 
   desc "Post recently expired memberships (last day by default) to Slack."
   task :expired_memberships, [:expires_at] => [:environment] do |t, args|
-    Stats.new(slack: true).expired_memberships(expires_at ||= 1.day.ago)
+    Slack.say Stats.expired_memberships(expires_at ||= 1.day.ago),
+      username: "Recently Expired Memberships",
+      channel: "#stripe",
+      icon_emoji: ":chart_with_downwards_trend:"
   end
 
   desc "Post projected monthly revenue to Slack."
   task :monthly_revenue_projection => [:environment] do
-    Stats.new(slack: true).monthly_revenue_projection
+    Slack.say Stats.monthly_revenue_projection,
+      username: "Subscribers",
+      channel: "#stripe",
+      icon_emoji: ":chart_with_upwards_trend:"
   end
 end


### PR DESCRIPTION
This class has an initialisation option where we can enable/disable slack posting (though it also won't let us use Slack unless we're in test mode - so that we can make sure it works - or unless a slack team is present)

Also added `rake stats:monthly_revenue_projection` which was previously hardcoded into the `StripeEvent::Subscription::Changed` hook