### PR TITLE
Prevent failures when the user doesn't have a plan.

### DIFF
--- a/lib/stripe_event/base.rb
+++ b/lib/stripe_event/base.rb
@@ -1,9 +1,15 @@
 module StripeEvent
   class Base
 
+    def stripe_customer_for_event(event)
+      Stripe::Customer.retrieve(event.data.object.customer).tap do |customer|
+        customer = nil if customer.respond_to?(:deleted?) && customer.deleted?
+      end
+    end
+
     def user_for_event(event)
-      customer = Stripe::Customer.retrieve(event.data.object.customer)
-      return nil if customer.respond_to?(:deleted?) && customer.deleted?
+      customer = stripe_customer_for_event(event)
+      return nil if customer.nil?
 
       event_user = User.includes(:membership).where(stripe_id: customer.id).first
       return nil if event_user.nil?

--- a/spec/fixtures/vcr/Stripe_webhooks/customer_source_created/runs_our_hook.yml
+++ b/spec/fixtures/vcr/Stripe_webhooks/customer_source_created/runs_our_hook.yml
@@ -83,7 +83,7 @@ http_interactions:
               "address_zip_check": null,
               "dynamic_last4": null,
               "metadata": {},
-              "customer": "cus_5zX7jk6DxkTfzh"
+              "customer": "cus_8U1TcYRfvl8VqP"
             }
           },
           "object": "event",
@@ -91,6 +91,6 @@ http_interactions:
           "request": "iar_5zX7ZYrwpRhzH4",
           "api_version": "2015-02-18"
         }
-    http_version: 
+    http_version:
   recorded_at: Fri, 03 Apr 2015 16:57:36 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/Stripe_webhooks/customer_source_created/when_user_doesn_t_exist_yet/returns_a_404.yml
+++ b/spec/fixtures/vcr/Stripe_webhooks/customer_source_created/when_user_doesn_t_exist_yet/returns_a_404.yml
@@ -83,7 +83,7 @@ http_interactions:
               "address_zip_check": null,
               "dynamic_last4": null,
               "metadata": {},
-              "customer": "cus_5zX7jk6DxkTfzh"
+              "customer": "cus_8U1TcYRfvl8VqP"
             }
           },
           "object": "event",
@@ -91,6 +91,6 @@ http_interactions:
           "request": "iar_5zX7ZYrwpRhzH4",
           "api_version": "2015-02-18"
         }
-    http_version: 
+    http_version:
   recorded_at: Fri, 03 Apr 2015 16:57:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/Stripe_webhooks/customer_subscription_created/runs_our_hook.yml
+++ b/spec/fixtures/vcr/Stripe_webhooks/customer_subscription_created/runs_our_hook.yml
@@ -80,7 +80,7 @@ http_interactions:
               "object": "subscription",
               "start": 1428080032,
               "status": "active",
-              "customer": "cus_5zX7jk6DxkTfzh",
+              "customer": "cus_8U1TcYRfvl8VqP",
               "cancel_at_period_end": false,
               "current_period_start": 1428080032,
               "current_period_end": 1430672032,
@@ -100,7 +100,7 @@ http_interactions:
           "request": "iar_5zX7MhAJ6RJnbJ",
           "api_version": "2015-02-18"
         }
-    http_version: 
+    http_version:
   recorded_at: Fri, 03 Apr 2015 16:57:33 GMT
 - request:
     method: get
@@ -483,7 +483,7 @@ http_interactions:
             }
           ]
         }
-    http_version: 
+    http_version:
   recorded_at: Fri, 03 Apr 2015 16:57:34 GMT
 - request:
     method: get
@@ -549,7 +549,7 @@ http_interactions:
             {
               "object": "customer",
               "created": 1428080030,
-              "id": "cus_5zX7jk6DxkTfzh",
+              "id": "cus_8U1TcYRfvl8VqP",
               "livemode": false,
               "description": null,
               "email": "alice@example.com",
@@ -559,7 +559,7 @@ http_interactions:
                 "object": "list",
                 "total_count": 1,
                 "has_more": false,
-                "url": "/v1/customers/cus_5zX7jk6DxkTfzh/subscriptions",
+                "url": "/v1/customers/cus_8U1TcYRfvl8VqP/subscriptions",
                 "data": [
                   {
                     "id": "sub_5zX7ha6aVZ6Xeh",
@@ -580,7 +580,7 @@ http_interactions:
                     "object": "subscription",
                     "start": 1428080032,
                     "status": "active",
-                    "customer": "cus_5zX7jk6DxkTfzh",
+                    "customer": "cus_8U1TcYRfvl8VqP",
                     "cancel_at_period_end": false,
                     "current_period_start": 1428080032,
                     "current_period_end": 1430672032,
@@ -603,7 +603,7 @@ http_interactions:
                 "object": "list",
                 "total_count": 1,
                 "has_more": false,
-                "url": "/v1/customers/cus_5zX7jk6DxkTfzh/sources",
+                "url": "/v1/customers/cus_8U1TcYRfvl8VqP/sources",
                 "data": [
                   {
                     "id": "card_15nY3CAcWgwn5pBtwYqmzfec",
@@ -627,7 +627,7 @@ http_interactions:
                     "address_zip_check": null,
                     "dynamic_last4": null,
                     "metadata": {},
-                    "customer": "cus_5zX7jk6DxkTfzh"
+                    "customer": "cus_8U1TcYRfvl8VqP"
                   }
                 ]
               },
@@ -635,7 +635,7 @@ http_interactions:
             }
           ]
         }
-    http_version: 
+    http_version:
   recorded_at: Fri, 03 Apr 2015 16:57:35 GMT
 - request:
     method: get
@@ -787,7 +787,7 @@ http_interactions:
             }
           ]
         }
-    http_version: 
+    http_version:
   recorded_at: Fri, 03 Apr 2015 16:57:35 GMT
 - request:
     method: get
@@ -851,7 +851,7 @@ http_interactions:
           "url": "/v1/customers",
           "data": []
         }
-    http_version: 
+    http_version:
   recorded_at: Tue, 30 Jun 2015 03:32:40 GMT
 - request:
     method: get
@@ -915,7 +915,7 @@ http_interactions:
           "url": "/v1/customers",
           "data": []
         }
-    http_version: 
+    http_version:
   recorded_at: Tue, 30 Jun 2015 03:32:41 GMT
 - request:
     method: get
@@ -1365,7 +1365,7 @@ http_interactions:
             }
           ]
         }
-    http_version: 
+    http_version:
   recorded_at: Tue, 30 Jun 2015 03:32:41 GMT
 - request:
     method: get
@@ -1519,7 +1519,7 @@ http_interactions:
             }
           ]
         }
-    http_version: 
+    http_version:
   recorded_at: Sat, 03 Oct 2015 03:04:40 GMT
 - request:
     method: get
@@ -1583,7 +1583,7 @@ http_interactions:
           "url": "/v1/customers",
           "data": []
         }
-    http_version: 
+    http_version:
   recorded_at: Sat, 03 Oct 2015 03:04:40 GMT
 - request:
     method: get
@@ -1647,7 +1647,7 @@ http_interactions:
           "url": "/v1/customers",
           "data": []
         }
-    http_version: 
+    http_version:
   recorded_at: Sat, 03 Oct 2015 03:04:41 GMT
 - request:
     method: get
@@ -1711,7 +1711,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:32:13 GMT
 - request:
     method: get
@@ -1775,7 +1775,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:32:14 GMT
 - request:
     method: get
@@ -1839,7 +1839,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:32:14 GMT
 - request:
     method: get
@@ -1903,7 +1903,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:32:14 GMT
 - request:
     method: get
@@ -1967,7 +1967,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:32:14 GMT
 - request:
     method: get
@@ -2031,7 +2031,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:32:15 GMT
 - request:
     method: get
@@ -2095,7 +2095,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:32:15 GMT
 - request:
     method: get
@@ -2159,7 +2159,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:32:15 GMT
 - request:
     method: get
@@ -2223,7 +2223,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:03 GMT
 - request:
     method: get
@@ -2287,7 +2287,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:04 GMT
 - request:
     method: get
@@ -2351,7 +2351,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:04 GMT
 - request:
     method: get
@@ -2415,7 +2415,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:04 GMT
 - request:
     method: get
@@ -2479,7 +2479,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:04 GMT
 - request:
     method: get
@@ -2543,7 +2543,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:05 GMT
 - request:
     method: get
@@ -2607,7 +2607,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:05 GMT
 - request:
     method: get
@@ -2671,7 +2671,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:05 GMT
 - request:
     method: get
@@ -2735,7 +2735,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:12 GMT
 - request:
     method: get
@@ -2799,7 +2799,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:12 GMT
 - request:
     method: get
@@ -2863,7 +2863,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:12 GMT
 - request:
     method: get
@@ -2927,7 +2927,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:12 GMT
 - request:
     method: get
@@ -2991,7 +2991,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:12 GMT
 - request:
     method: get
@@ -3055,7 +3055,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:13 GMT
 - request:
     method: get
@@ -3119,7 +3119,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:13 GMT
 - request:
     method: get
@@ -3183,6 +3183,6 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 25 Jan 2016 08:36:13 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/Stripe_webhooks/invoice_payment_succeeded/runs_our_hook.yml
+++ b/spec/fixtures/vcr/Stripe_webhooks/invoice_payment_succeeded/runs_our_hook.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.stripe.com/v1/events/evt_15nY3IAcWgwn5pBtGGpjLCBH
+    uri: https://api.stripe.com/v1/events/evt_18LmVXAcWgwn5pBtJT0nT3hc
     body:
       encoding: US-ASCII
       string: ''
@@ -12,15 +12,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Stripe/v1 RubyBindings/1.20.3
+      - Stripe/v1 RubyBindings/1.43.0
       Authorization:
       - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"1.20.3","lang":"ruby","lang_version":"2.2.1 p85 (2015-02-26)","platform":"x86_64-darwin14","publisher":"stripe","uname":"Darwin
-        ivy.local 14.1.0 Darwin Kernel Version 14.1.0: Thu Feb 26 19:26:47 PST 2015;
-        root:xnu-2782.10.73~1/RELEASE_X86_64 x86_64"}'
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        thin.fritz.box 15.6.0 Darwin Kernel Version 15.6.0: Wed Jun  1 11:10:40 PDT
+        2016; root:xnu-3248.60.4~4/RELEASE_X86_64 x86_64","hostname":"thin.fritz.box"}'
   response:
     status:
       code: 200
@@ -29,11 +29,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 03 Apr 2015 16:57:39 GMT
+      - Mon, 13 Jun 2016 04:19:21 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '2352'
+      - '2324'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -47,103 +47,104 @@ http_interactions:
       Cache-Control:
       - no-cache, no-store
       Request-Id:
-      - req_fDNH4MBDN7jEwR6s
+      - req_8d2d4OFo0No6Fo
       Stripe-Version:
-      - '2015-02-18'
+      - '2015-04-07'
       Strict-Transport-Security:
       - max-age=31556926; includeSubDomains
     body:
       encoding: UTF-8
       string: |
         {
-          "id": "evt_15nY3IAcWgwn5pBtGGpjLCBH",
-          "created": 1428080032,
-          "livemode": false,
-          "type": "invoice.payment_succeeded",
+          "id": "evt_18LmVXAcWgwn5pBtJT0nT3hc",
+          "object": "event",
+          "api_version": "2015-04-07",
+          "created": 1465791423,
           "data": {
             "object": {
-              "date": 1428080032,
-              "id": "in_15nY3IAcWgwn5pBtMz4J7Ljn",
-              "period_start": 1428080032,
-              "period_end": 1428080032,
+              "id": "in_18LmVWAcWgwn5pBttRijTnJy",
+              "object": "invoice",
+              "amount_due": 0,
+              "application_fee": null,
+              "attempt_count": 0,
+              "attempted": true,
+              "charge": null,
+              "closed": true,
+              "currency": "usd",
+              "customer": "cus_8U1TcYRfvl8VqP",
+              "date": 1465791422,
+              "description": null,
+              "discount": null,
+              "ending_balance": 0,
+              "forgiven": false,
               "lines": {
                 "object": "list",
-                "total_count": 1,
-                "has_more": false,
-                "url": "/v1/invoices/in_15nY3IAcWgwn5pBtMz4J7Ljn/lines",
                 "data": [
                   {
-                    "id": "sub_5zX7ha6aVZ6Xeh",
+                    "id": "sub_8d2aO41CzC39fS",
                     "object": "line_item",
-                    "type": "subscription",
-                    "livemode": false,
-                    "amount": 4000,
+                    "amount": 0,
                     "currency": "usd",
-                    "proration": false,
-                    "period": {
-                      "start": 1428080032,
-                      "end": 1430672032
-                    },
-                    "subscription": null,
-                    "quantity": 1,
-                    "plan": {
-                      "interval": "month",
-                      "name": "Ruby Together Individual Membership",
-                      "created": 1425204514,
-                      "amount": 4000,
-                      "currency": "usd",
-                      "id": "individual",
-                      "object": "plan",
-                      "livemode": false,
-                      "interval_count": 1,
-                      "trial_period_days": null,
-                      "metadata": {},
-                      "statement_descriptor": null
-                    },
                     "description": null,
                     "discountable": true,
-                    "metadata": {}
+                    "livemode": false,
+                    "metadata": {},
+                    "period": {
+                      "start": 1465791422,
+                      "end": 1592031599
+                    },
+                    "plan": {
+                      "id": "corporate_ruby",
+                      "object": "plan",
+                      "amount": 500000,
+                      "created": 1453710393,
+                      "currency": "usd",
+                      "interval": "month",
+                      "interval_count": 1,
+                      "livemode": false,
+                      "metadata": {},
+                      "name": "Ruby Membership",
+                      "statement_descriptor": null,
+                      "trial_period_days": null
+                    },
+                    "proration": false,
+                    "quantity": 1,
+                    "subscription": null,
+                    "type": "subscription"
                   }
-                ]
+                ],
+                "has_more": false,
+                "total_count": 1,
+                "url": "/v1/invoices/in_18LmVWAcWgwn5pBttRijTnJy/lines"
               },
-              "subtotal": 4000,
-              "total": 4000,
-              "customer": "cus_5zX7jk6DxkTfzh",
-              "object": "invoice",
-              "attempted": true,
-              "closed": true,
-              "forgiven": false,
-              "paid": true,
               "livemode": false,
-              "attempt_count": 1,
-              "amount_due": 4000,
-              "currency": "usd",
-              "starting_balance": 0,
-              "ending_balance": 0,
-              "next_payment_attempt": null,
-              "webhooks_delivered_at": null,
-              "charge": "ch_15nY3IAcWgwn5pBtLSKgqlme",
-              "discount": null,
-              "application_fee": null,
-              "subscription": "sub_5zX7ha6aVZ6Xeh",
-              "tax_percent": null,
-              "tax": null,
               "metadata": {},
+              "next_payment_attempt": null,
+              "paid": true,
+              "period_end": 1465791422,
+              "period_start": 1465791422,
+              "receipt_number": null,
+              "starting_balance": 0,
               "statement_descriptor": null,
-              "description": null,
-              "receipt_number": null
+              "subscription": "sub_8d2aO41CzC39fS",
+              "subtotal": 0,
+              "tax": null,
+              "tax_percent": null,
+              "total": 0,
+              "webhooks_delivered_at": null,
+              "payment": null
             }
           },
-          "object": "event",
+          "livemode": false,
           "pending_webhooks": 0,
-          "request": "iar_5zX7MhAJ6RJnbJ",
-          "api_version": "2015-02-18"
+          "request": "req_8d2aKYUYmY0xaW",
+          "type": "invoice.payment_succeeded"
         }
     http_version: 
-  recorded_at: Fri, 03 Apr 2015 16:57:38 GMT
+  recorded_at: Mon, 13 Jun 2016 04:19:21 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/customers/cus_5zX7jk6DxkTfzh
+    uri: https://api.stripe.com/v1/customers/cus_8U1TcYRfvl8VqP
     body:
       encoding: US-ASCII
       string: ''
@@ -153,15 +154,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Stripe/v1 RubyBindings/1.20.3
+      - Stripe/v1 RubyBindings/1.43.0
       Authorization:
       - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-User-Agent:
-      - '{"bindings_version":"1.20.3","lang":"ruby","lang_version":"2.2.1 p85 (2015-02-26)","platform":"x86_64-darwin14","publisher":"stripe","uname":"Darwin
-        ivy.local 14.1.0 Darwin Kernel Version 14.1.0: Thu Feb 26 19:26:47 PST 2015;
-        root:xnu-2782.10.73~1/RELEASE_X86_64 x86_64"}'
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        thin.fritz.box 15.6.0 Darwin Kernel Version 15.6.0: Wed Jun  1 11:10:40 PDT
+        2016; root:xnu-3248.60.4~4/RELEASE_X86_64 x86_64","hostname":"thin.fritz.box"}'
   response:
     status:
       code: 200
@@ -170,11 +171,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 03 Apr 2015 16:57:40 GMT
+      - Mon, 13 Jun 2016 04:19:22 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '2346'
+      - '2464'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -188,101 +189,253 @@ http_interactions:
       Cache-Control:
       - no-cache, no-store
       Request-Id:
-      - req_6pP0DQiDqx7oQAIN
+      - req_8d2dWpldKTD25b
       Stripe-Version:
-      - '2015-02-18'
+      - '2015-04-07'
       Strict-Transport-Security:
       - max-age=31556926; includeSubDomains
     body:
       encoding: UTF-8
       string: |
         {
+          "id": "cus_8U1TcYRfvl8VqP",
           "object": "customer",
-          "created": 1428080030,
-          "id": "cus_5zX7jk6DxkTfzh",
-          "livemode": false,
-          "description": null,
-          "email": "alice@example.com",
-          "delinquent": false,
-          "metadata": {},
-          "subscriptions": {
-            "object": "list",
-            "total_count": 1,
-            "has_more": false,
-            "url": "/v1/customers/cus_5zX7jk6DxkTfzh/subscriptions",
-            "data": [
-              {
-                "id": "sub_5zX7ha6aVZ6Xeh",
-                "plan": {
-                  "interval": "month",
-                  "name": "Ruby Together Individual Membership",
-                  "created": 1425204514,
-                  "amount": 4000,
-                  "currency": "usd",
-                  "id": "individual",
-                  "object": "plan",
-                  "livemode": false,
-                  "interval_count": 1,
-                  "trial_period_days": null,
-                  "metadata": {},
-                  "statement_descriptor": null
-                },
-                "object": "subscription",
-                "start": 1428080032,
-                "status": "active",
-                "customer": "cus_5zX7jk6DxkTfzh",
-                "cancel_at_period_end": false,
-                "current_period_start": 1428080032,
-                "current_period_end": 1430672032,
-                "ended_at": null,
-                "trial_start": null,
-                "trial_end": null,
-                "canceled_at": null,
-                "quantity": 1,
-                "application_fee_percent": null,
-                "discount": null,
-                "tax_percent": null,
-                "metadata": {}
-              }
-            ]
-          },
-          "discount": null,
           "account_balance": 0,
+          "business_vat_id": null,
+          "created": 1463711504,
           "currency": "usd",
+          "default_source": "card_18D3RNAcWgwn5pBtT4l6eaNK",
+          "delinquent": false,
+          "description": "Fails invoice payments",
+          "discount": null,
+          "email": "alice@example.com",
+          "livemode": false,
+          "metadata": {},
+          "shipping": null,
           "sources": {
             "object": "list",
-            "total_count": 1,
-            "has_more": false,
-            "url": "/v1/customers/cus_5zX7jk6DxkTfzh/sources",
             "data": [
               {
-                "id": "card_15nY3CAcWgwn5pBtwYqmzfec",
+                "id": "card_18D3RNAcWgwn5pBtT4l6eaNK",
                 "object": "card",
-                "last4": "4242",
-                "brand": "Visa",
-                "funding": "credit",
-                "exp_month": 2,
-                "exp_year": 2022,
-                "fingerprint": "Jus3vECqxH1Ctmdh",
-                "country": "US",
-                "name": "alice@example.com",
-                "address_line1": null,
-                "address_line2": null,
                 "address_city": null,
+                "address_country": null,
+                "address_line1": null,
+                "address_line1_check": null,
+                "address_line2": null,
                 "address_state": null,
                 "address_zip": null,
-                "address_country": null,
-                "cvc_check": "pass",
-                "address_line1_check": null,
                 "address_zip_check": null,
+                "brand": "Visa",
+                "country": "US",
+                "customer": "cus_8U1TcYRfvl8VqP",
+                "cvc_check": null,
                 "dynamic_last4": null,
+                "exp_month": 5,
+                "exp_year": 2017,
+                "fingerprint": "FLcmEzCB80ITlNjt",
+                "funding": "credit",
+                "last4": "0341",
                 "metadata": {},
-                "customer": "cus_5zX7jk6DxkTfzh"
+                "name": null,
+                "tokenization_method": null
               }
-            ]
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_8U1TcYRfvl8VqP/sources"
           },
-          "default_source": "card_15nY3CAcWgwn5pBtwYqmzfec"
+          "subscriptions": {
+            "object": "list",
+            "data": [
+              {
+                "id": "sub_8d2aO41CzC39fS",
+                "object": "subscription",
+                "application_fee_percent": null,
+                "cancel_at_period_end": false,
+                "canceled_at": null,
+                "created": 1465791422,
+                "current_period_end": 1592031599,
+                "current_period_start": 1465791422,
+                "customer": "cus_8U1TcYRfvl8VqP",
+                "discount": null,
+                "ended_at": null,
+                "metadata": {},
+                "plan": {
+                  "id": "corporate_ruby",
+                  "object": "plan",
+                  "amount": 500000,
+                  "created": 1453710393,
+                  "currency": "usd",
+                  "interval": "month",
+                  "interval_count": 1,
+                  "livemode": false,
+                  "metadata": {},
+                  "name": "Ruby Membership",
+                  "statement_descriptor": null,
+                  "trial_period_days": null
+                },
+                "quantity": 1,
+                "start": 1465791422,
+                "status": "trialing",
+                "tax_percent": null,
+                "trial_end": 1592031599,
+                "trial_start": 1465791422
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_8U1TcYRfvl8VqP/subscriptions"
+          }
         }
     http_version: 
-  recorded_at: Fri, 03 Apr 2015 16:57:39 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Mon, 13 Jun 2016 04:19:22 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/customers/cus_8U1TcYRfvl8VqP
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        thin.fritz.box 15.6.0 Darwin Kernel Version 15.6.0: Wed Jun  1 11:10:40 PDT
+        2016; root:xnu-3248.60.4~4/RELEASE_X86_64 x86_64","hostname":"thin.fritz.box"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 13 Jun 2016 04:19:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2464'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8d2dZgjBY4UXie
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_8U1TcYRfvl8VqP",
+          "object": "customer",
+          "account_balance": 0,
+          "business_vat_id": null,
+          "created": 1463711504,
+          "currency": "usd",
+          "default_source": "card_18D3RNAcWgwn5pBtT4l6eaNK",
+          "delinquent": false,
+          "description": "Fails invoice payments",
+          "discount": null,
+          "email": "alice@example.com",
+          "livemode": false,
+          "metadata": {},
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "card_18D3RNAcWgwn5pBtT4l6eaNK",
+                "object": "card",
+                "address_city": null,
+                "address_country": null,
+                "address_line1": null,
+                "address_line1_check": null,
+                "address_line2": null,
+                "address_state": null,
+                "address_zip": null,
+                "address_zip_check": null,
+                "brand": "Visa",
+                "country": "US",
+                "customer": "cus_8U1TcYRfvl8VqP",
+                "cvc_check": null,
+                "dynamic_last4": null,
+                "exp_month": 5,
+                "exp_year": 2017,
+                "fingerprint": "FLcmEzCB80ITlNjt",
+                "funding": "credit",
+                "last4": "0341",
+                "metadata": {},
+                "name": null,
+                "tokenization_method": null
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_8U1TcYRfvl8VqP/sources"
+          },
+          "subscriptions": {
+            "object": "list",
+            "data": [
+              {
+                "id": "sub_8d2aO41CzC39fS",
+                "object": "subscription",
+                "application_fee_percent": null,
+                "cancel_at_period_end": false,
+                "canceled_at": null,
+                "created": 1465791422,
+                "current_period_end": 1592031599,
+                "current_period_start": 1465791422,
+                "customer": "cus_8U1TcYRfvl8VqP",
+                "discount": null,
+                "ended_at": null,
+                "metadata": {},
+                "plan": {
+                  "id": "corporate_ruby",
+                  "object": "plan",
+                  "amount": 500000,
+                  "created": 1453710393,
+                  "currency": "usd",
+                  "interval": "month",
+                  "interval_count": 1,
+                  "livemode": false,
+                  "metadata": {},
+                  "name": "Ruby Membership",
+                  "statement_descriptor": null,
+                  "trial_period_days": null
+                },
+                "quantity": 1,
+                "start": 1465791422,
+                "status": "trialing",
+                "tax_percent": null,
+                "trial_end": 1592031599,
+                "trial_start": 1465791422
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_8U1TcYRfvl8VqP/subscriptions"
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 13 Jun 2016 04:19:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/stripe_events_spec.rb
+++ b/spec/requests/stripe_events_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Stripe webhooks", :vcr do
 
   describe "customer.source.created" do
     it "runs our hook" do
-      user = User.create!(stripe_id: "cus_5zX7jk6DxkTfzh", email: "alice@example.com")
+      user = User.create!(stripe_id: "cus_8U1TcYRfvl8VqP", email: "alice@example.com")
       membership = Membership.create(user: user, card_last4: "1234")
 
       expect {
@@ -22,12 +22,12 @@ RSpec.describe "Stripe webhooks", :vcr do
   end
 
   describe "invoice.payment_succeeded" do
-    let(:user) { User.create!(stripe_id: "cus_5zX7jk6DxkTfzh", email: "alice@example.com") }
-    let(:membership) { Membership.create(user: user, card_last4: "4242") }
+    let!(:user) { User.create!(stripe_id: "cus_8U1TcYRfvl8VqP", email: "alice@example.com") }
+    let!(:membership) { Membership.create(user: user, card_last4: "4242") }
 
     it "runs our hook" do
       expect {
-        post "/stripe/events", id: "evt_15nY3IAcWgwn5pBtGGpjLCBH"
+        post "/stripe/events", id: "evt_18LmVXAcWgwn5pBtJT0nT3hc"
       }.to change { membership.reload.expires_at }
     end
   end
@@ -55,7 +55,7 @@ RSpec.describe "Stripe webhooks", :vcr do
     let(:user) { double(User, membership: membership) }
 
     it "runs our hook" do
-      expect(User).to receive(:find_by_stripe_id).with("cus_5zX7jk6DxkTfzh").and_return(user)
+      expect(User).to receive(:find_by_stripe_id).with("cus_8U1TcYRfvl8VqP").and_return(user)
       expect(membership).to receive(:update).with(kind: "individual")
 
       expect(Slack).to receive(:say).with(message, slack_options)


### PR DESCRIPTION
This happens when we accept payments for other things, that are not core to Ruby Together, so there is no MembershipPlanwith the correct id and therefore no user.

What this changes is that it won't try to process these events.

I've also had to update the customer reference for `alice@example.com` as tests were failing due to the when fetching new VCR cassettes. 