### PR TITLE
Fix the token we send members when their payment fails.

### DIFF
--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -2,7 +2,7 @@ class PaymentMailer < ApplicationMailer
 
   def failure(user)
     @name = user.name.presence || "there" # "Hi Alice," or "Hi there,"
-    @token = user.reset_password_token
+    @token = user.generate_reset_password_token!
     mail to: user.email, subject: "Your payment to Ruby Together failed."
   end
 

--- a/spec/requests/stripe_events_spec.rb
+++ b/spec/requests/stripe_events_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe "Stripe webhooks", :vcr do
       }.to change(ActionMailer::Base.deliveries, :count).by(1)
 
       expect(ActionMailer::Base.deliveries.last.to).to include(user.email)
+      token = ActionMailer::Base.deliveries.last.body.parts.first.body.to_s.scan(
+        %r{\?token=(.*)}
+      ).flatten.first.to_s.chop
+      expect(token).to be_present, "Password reset token was not found in the email."
+      expect(User.with_reset_password_token(token)).to eq(user)
     end
   end
 


### PR DESCRIPTION
Previously this was not guaranteed to be present,
and was potentially using the wrong part of the token.