### PR TITLE
Required Stripe API update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle
 /.env.local
+/.rspec_failures
 /log/*
 /tmp

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -5,6 +5,11 @@ end
 
 Stripe.api_key = Rails.configuration.x.stripe_secret_key
 
+# Override Stripe API version to allow testing upgrades
+if ENV.has_key?("STRIPE_API_VERSION")
+  Stripe.api_version = ENV.fetch("STRIPE_API_VERSION")
+end
+
 # Enable HTTP basic auth if secret is set (for prod but not staging)
 if ENV.has_key?("STRIPE_WEBHOOK_SECRET")
   StripeEvent.authentication_secret = ENV.fetch("STRIPE_WEBHOOK_SECRET")
@@ -16,7 +21,6 @@ require "stripe_event/subscription/changed"
 require "stripe_event/subscription/deleted"
 
 StripeEvent.configure do |events|
-
   events.subscribe "invoice.payment_succeeded",
     StripeEvent::Invoice::PaymentSucceeded.new
 
@@ -35,5 +39,4 @@ StripeEvent.configure do |events|
 
   events.subscribe "customer.subscription.deleted",
     StripeEvent::Subscription::Deleted.new
-
 end

--- a/lib/membership_plan.rb
+++ b/lib/membership_plan.rb
@@ -32,10 +32,10 @@ MembershipPlan = Struct.new(:id, :shortname, :name, :interval, :amount, :currenc
   end
 
   def subscriber_count
-    Stripe::Customer.all(
-      "include[]"=>"total_count",
-      "limit" => "1",
-      "subscription[plan]" => id
+    Stripe::Subscription.list(
+      "include[]" => "total_count",
+      "limit" => 1,
+      "plan" => id
     ).total_count
   end
 

--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -1,4 +1,8 @@
 class Stats
+  def self.debug(message)
+    puts(message) if ENV["DEBUG"]
+  end
+
   def self.since(last_date)
     new_members = Membership.active.since(last_date)
     groups = new_members.group_by(&:kind)
@@ -6,7 +10,7 @@ class Stats
     plans.select{|plan| groups[plan.id] }.
       map{|plan| [plan, groups[plan.id]] }.
       each do |plan, group|
-        puts "#{group.size} new #{plan.shortname} #{"member".pluralize(group.size)}: #{group.map(&:name).compact.to_sentence}"
+        debug "#{group.size} new #{plan.shortname} #{"member".pluralize(group.size)}: #{group.map(&:name).compact.to_sentence}"
       end
 
     companies, people = new_members.partition(&:corporate?)

--- a/lib/stripe_event/customer/source/created.rb
+++ b/lib/stripe_event/customer/source/created.rb
@@ -1,0 +1,16 @@
+module StripeEvent
+  module Customer
+    module Source
+      class Created < Base
+
+        def call(event)
+          card = event.data.object
+          user_id = User.where(stripe_id: card.customer).pluck(:id).first
+          membership = Membership.where(user_id: user_id).first!
+          membership.update!(card_brand: card.brand, card_last4: card.last4)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/stripe_event/customer/source/created.rb
+++ b/lib/stripe_event/customer/source/created.rb
@@ -5,8 +5,8 @@ module StripeEvent
 
         def call(event)
           card = event.data.object
-          user_id = User.where(stripe_id: card.customer).pluck(:id).first
-          membership = Membership.where(user_id: user_id).first!
+          user = User.where(stripe_id: card.customer).first!
+          membership = Membership.where(user: user).first!
           membership.update!(card_brand: card.brand, card_last4: card.last4)
         end
 

--- a/spec/fixtures/vcr/Stats/monthly_revenue_projection/is_accurate.yml
+++ b/spec/fixtures/vcr/Stats/monthly_revenue_projection/is_accurate.yml
@@ -147,7 +147,7 @@ http_interactions:
             "url": "/v1/customers/cus_8ff9tXc0ra8927/subscriptions"
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:57:58 GMT
 - request:
     method: get
@@ -296,7 +296,7 @@ http_interactions:
             "url": "/v1/customers/cus_8ff9KmLm6ZG9oW/subscriptions"
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:57:59 GMT
 - request:
     method: get
@@ -445,7 +445,7 @@ http_interactions:
             "url": "/v1/customers/cus_8ff95K9mtLvC4w/subscriptions"
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:58:00 GMT
 - request:
     method: get
@@ -558,7 +558,7 @@ http_interactions:
             "url": "/v1/customers/cus_8ffUbWEM9gofdR/subscriptions"
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:58:01 GMT
 - request:
     method: get
@@ -715,7 +715,7 @@ http_interactions:
           "total_count": 1,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:58:02 GMT
 - request:
     method: get
@@ -779,7 +779,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:58:02 GMT
 - request:
     method: get
@@ -843,7 +843,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:58:03 GMT
 - request:
     method: get
@@ -1000,7 +1000,7 @@ http_interactions:
           "total_count": 1,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:58:04 GMT
 - request:
     method: get
@@ -1064,7 +1064,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:58:05 GMT
 - request:
     method: get
@@ -1128,7 +1128,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:58:06 GMT
 - request:
     method: get
@@ -1192,7 +1192,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:58:07 GMT
 - request:
     method: get
@@ -1349,6 +1349,662 @@ http_interactions:
           "total_count": 1,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:58:08 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_onyx
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1074'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVeNTeefDU8P1
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffekCDvEWGdVX",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466397994,
+              "current_period_end": 1471668394,
+              "current_period_start": 1468989994,
+              "customer": "cus_8ff95K9mtLvC4w",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "corporate_onyx",
+                "object": "plan",
+                "amount": 5000,
+                "created": 1453710392,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Onyx Memberbership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466397994,
+              "status": "active",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:55 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_emerald
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVeW6VJR90Odx
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:55 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_jade
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVeF3WKiNuQkZ
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:56 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_ruby
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1074'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVeoQKPqQR26N
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffpwHGFkcia4E",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466398652,
+              "current_period_end": 1471669052,
+              "current_period_start": 1468990652,
+              "customer": "cus_8U1TcYRfvl8VqP",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "corporate_ruby",
+                "object": "plan",
+                "amount": 500000,
+                "created": 1453710393,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Ruby Membership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466398652,
+              "status": "past_due",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": true,
+          "total_count": 2,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:56 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_sapphire
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVeZPMN4KUb6B
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:56 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_topaz
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1074'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVeuKWcjRgi8b
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffujqdnveuPZH",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466398957,
+              "current_period_end": 1471669357,
+              "current_period_start": 1468990957,
+              "customer": "cus_8ffUbWEM9gofdR",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "corporate_topaz",
+                "object": "plan",
+                "amount": 20000,
+                "created": 1453710394,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Topaz Membership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466398977,
+              "status": "active",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:56 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=friend
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVeSfDShuUPUa
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:56 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=individual
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:57 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1072'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVeIB4n7Tz4hK
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffdAZa04rNUwK",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466397966,
+              "current_period_end": 1471668366,
+              "current_period_start": 1468989966,
+              "customer": "cus_8ff9KmLm6ZG9oW",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "individual",
+                "object": "plan",
+                "amount": 4000,
+                "created": 1453710396,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Developer Membership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466397966,
+              "status": "active",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/Stats/since/is_accurate.yml
+++ b/spec/fixtures/vcr/Stats/since/is_accurate.yml
@@ -147,7 +147,7 @@ http_interactions:
             "url": "/v1/customers/cus_8ff9tXc0ra8927/subscriptions"
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:56:44 GMT
 - request:
     method: get
@@ -296,7 +296,7 @@ http_interactions:
             "url": "/v1/customers/cus_8ff9KmLm6ZG9oW/subscriptions"
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:56:45 GMT
 - request:
     method: get
@@ -445,7 +445,7 @@ http_interactions:
             "url": "/v1/customers/cus_8ff95K9mtLvC4w/subscriptions"
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:56:46 GMT
 - request:
     method: get
@@ -558,7 +558,7 @@ http_interactions:
             "url": "/v1/customers/cus_8ffUbWEM9gofdR/subscriptions"
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:56:47 GMT
 - request:
     method: get
@@ -715,7 +715,7 @@ http_interactions:
           "total_count": 1,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:56:47 GMT
 - request:
     method: get
@@ -779,7 +779,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:56:48 GMT
 - request:
     method: get
@@ -843,7 +843,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:56:49 GMT
 - request:
     method: get
@@ -1000,7 +1000,7 @@ http_interactions:
           "total_count": 1,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:56:50 GMT
 - request:
     method: get
@@ -1064,7 +1064,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:56:51 GMT
 - request:
     method: get
@@ -1128,7 +1128,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:56:52 GMT
 - request:
     method: get
@@ -1192,7 +1192,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:56:53 GMT
 - request:
     method: get
@@ -1349,6 +1349,662 @@ http_interactions:
           "total_count": 1,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 20 Jun 2016 04:56:54 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_onyx
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1074'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVe7Wi5srw865
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffekCDvEWGdVX",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466397994,
+              "current_period_end": 1471668394,
+              "current_period_start": 1468989994,
+              "customer": "cus_8ff95K9mtLvC4w",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "corporate_onyx",
+                "object": "plan",
+                "amount": 5000,
+                "created": 1453710392,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Onyx Memberbership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466397994,
+              "status": "active",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:53 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_emerald
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVedbbMp7Qj7m
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:53 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_jade
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVeb1egZhg0VX
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:54 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_ruby
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1074'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVeF1MQDNbvyP
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffpwHGFkcia4E",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466398652,
+              "current_period_end": 1471669052,
+              "current_period_start": 1468990652,
+              "customer": "cus_8U1TcYRfvl8VqP",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "corporate_ruby",
+                "object": "plan",
+                "amount": 500000,
+                "created": 1453710393,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Ruby Membership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466398652,
+              "status": "past_due",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": true,
+          "total_count": 2,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:54 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_sapphire
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVe6U9P09muUR
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:54 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_topaz
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1074'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVeEqezprOX4x
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffujqdnveuPZH",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466398957,
+              "current_period_end": 1471669357,
+              "current_period_start": 1468990957,
+              "customer": "cus_8ffUbWEM9gofdR",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "corporate_topaz",
+                "object": "plan",
+                "amount": 20000,
+                "created": 1453710394,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Topaz Membership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466398977,
+              "status": "active",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:54 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=friend
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVe94Nszm7A5F
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:54 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=individual
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:22:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1072'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVeOJVkzS5kCz
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffdAZa04rNUwK",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466397966,
+              "current_period_end": 1471668366,
+              "current_period_start": 1468989966,
+              "customer": "cus_8ff9KmLm6ZG9oW",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "individual",
+                "object": "plan",
+                "amount": 4000,
+                "created": 1453710396,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Developer Membership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466397966,
+              "status": "active",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:22:55 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/Stripe_webhooks/customer_subscription_created/runs_our_hook.yml
+++ b/spec/fixtures/vcr/Stripe_webhooks/customer_subscription_created/runs_our_hook.yml
@@ -100,7 +100,7 @@ http_interactions:
           "request": "iar_5zX7MhAJ6RJnbJ",
           "api_version": "2015-02-18"
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 03 Apr 2015 16:57:33 GMT
 - request:
     method: get
@@ -483,7 +483,7 @@ http_interactions:
             }
           ]
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 03 Apr 2015 16:57:34 GMT
 - request:
     method: get
@@ -635,7 +635,7 @@ http_interactions:
             }
           ]
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 03 Apr 2015 16:57:35 GMT
 - request:
     method: get
@@ -787,7 +787,7 @@ http_interactions:
             }
           ]
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 03 Apr 2015 16:57:35 GMT
 - request:
     method: get
@@ -851,7 +851,7 @@ http_interactions:
           "url": "/v1/customers",
           "data": []
         }
-    http_version:
+    http_version: 
   recorded_at: Tue, 30 Jun 2015 03:32:40 GMT
 - request:
     method: get
@@ -915,7 +915,7 @@ http_interactions:
           "url": "/v1/customers",
           "data": []
         }
-    http_version:
+    http_version: 
   recorded_at: Tue, 30 Jun 2015 03:32:41 GMT
 - request:
     method: get
@@ -1365,7 +1365,7 @@ http_interactions:
             }
           ]
         }
-    http_version:
+    http_version: 
   recorded_at: Tue, 30 Jun 2015 03:32:41 GMT
 - request:
     method: get
@@ -1519,7 +1519,7 @@ http_interactions:
             }
           ]
         }
-    http_version:
+    http_version: 
   recorded_at: Sat, 03 Oct 2015 03:04:40 GMT
 - request:
     method: get
@@ -1583,7 +1583,7 @@ http_interactions:
           "url": "/v1/customers",
           "data": []
         }
-    http_version:
+    http_version: 
   recorded_at: Sat, 03 Oct 2015 03:04:40 GMT
 - request:
     method: get
@@ -1647,7 +1647,7 @@ http_interactions:
           "url": "/v1/customers",
           "data": []
         }
-    http_version:
+    http_version: 
   recorded_at: Sat, 03 Oct 2015 03:04:41 GMT
 - request:
     method: get
@@ -1711,7 +1711,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:32:13 GMT
 - request:
     method: get
@@ -1775,7 +1775,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:32:14 GMT
 - request:
     method: get
@@ -1839,7 +1839,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:32:14 GMT
 - request:
     method: get
@@ -1903,7 +1903,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:32:14 GMT
 - request:
     method: get
@@ -1967,7 +1967,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:32:14 GMT
 - request:
     method: get
@@ -2031,7 +2031,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:32:15 GMT
 - request:
     method: get
@@ -2095,7 +2095,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:32:15 GMT
 - request:
     method: get
@@ -2159,7 +2159,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:32:15 GMT
 - request:
     method: get
@@ -2223,7 +2223,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:03 GMT
 - request:
     method: get
@@ -2287,7 +2287,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:04 GMT
 - request:
     method: get
@@ -2351,7 +2351,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:04 GMT
 - request:
     method: get
@@ -2415,7 +2415,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:04 GMT
 - request:
     method: get
@@ -2479,7 +2479,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:04 GMT
 - request:
     method: get
@@ -2543,7 +2543,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:05 GMT
 - request:
     method: get
@@ -2607,7 +2607,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:05 GMT
 - request:
     method: get
@@ -2671,7 +2671,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:05 GMT
 - request:
     method: get
@@ -2735,7 +2735,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:12 GMT
 - request:
     method: get
@@ -2799,7 +2799,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:12 GMT
 - request:
     method: get
@@ -2863,7 +2863,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:12 GMT
 - request:
     method: get
@@ -2927,7 +2927,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:12 GMT
 - request:
     method: get
@@ -2991,7 +2991,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:12 GMT
 - request:
     method: get
@@ -3055,7 +3055,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:13 GMT
 - request:
     method: get
@@ -3119,7 +3119,7 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:13 GMT
 - request:
     method: get
@@ -3183,6 +3183,662 @@ http_interactions:
           "total_count": 0,
           "url": "/v1/customers"
         }
-    http_version:
+    http_version: 
   recorded_at: Mon, 25 Jan 2016 08:36:13 GMT
-recorded_with: VCR 2.9.3
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_onyx
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1074'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVkxmIjeDtSTp
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffekCDvEWGdVX",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466397994,
+              "current_period_end": 1471668394,
+              "current_period_start": 1468989994,
+              "customer": "cus_8ff95K9mtLvC4w",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "corporate_onyx",
+                "object": "plan",
+                "amount": 5000,
+                "created": 1453710392,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Onyx Memberbership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466397994,
+              "status": "active",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:39 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_emerald
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVktlYYEnS8jK
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:39 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_jade
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVkTFjyluykwv
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:39 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_ruby
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1074'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVkvAMdjpVskx
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffpwHGFkcia4E",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466398652,
+              "current_period_end": 1471669052,
+              "current_period_start": 1468990652,
+              "customer": "cus_8U1TcYRfvl8VqP",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "corporate_ruby",
+                "object": "plan",
+                "amount": 500000,
+                "created": 1453710393,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Ruby Membership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466398652,
+              "status": "past_due",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": true,
+          "total_count": 2,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:39 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_sapphire
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVkdj6QiRaheb
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:39 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_topaz
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1074'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVk5Tstb9e5KO
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffujqdnveuPZH",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466398957,
+              "current_period_end": 1471669357,
+              "current_period_start": 1468990957,
+              "customer": "cus_8ffUbWEM9gofdR",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "corporate_topaz",
+                "object": "plan",
+                "amount": 20000,
+                "created": 1453710394,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Topaz Membership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466398977,
+              "status": "active",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:40 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=friend
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVkkkf61t4RJE
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:40 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=individual
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1072'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVk77qrFeSunS
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffdAZa04rNUwK",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466397966,
+              "current_period_end": 1471668366,
+              "current_period_start": 1468989966,
+              "customer": "cus_8ff9KmLm6ZG9oW",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "individual",
+                "object": "plan",
+                "amount": 4000,
+                "created": 1453710396,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Developer Membership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466397966,
+              "status": "active",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:40 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/Stripe_webhooks/customer_subscription_destroyed/runs_our_hook.yml
+++ b/spec/fixtures/vcr/Stripe_webhooks/customer_subscription_destroyed/runs_our_hook.yml
@@ -4022,4 +4022,660 @@ http_interactions:
         }
     http_version: 
   recorded_at: Mon, 25 Jan 2016 08:38:43 GMT
-recorded_with: VCR 2.9.3
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_onyx
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1074'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVkpkkUCfy42M
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffekCDvEWGdVX",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466397994,
+              "current_period_end": 1471668394,
+              "current_period_start": 1468989994,
+              "customer": "cus_8ff95K9mtLvC4w",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "corporate_onyx",
+                "object": "plan",
+                "amount": 5000,
+                "created": 1453710392,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Onyx Memberbership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466397994,
+              "status": "active",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:41 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_emerald
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVkiIuc0oaNOL
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:41 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_jade
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVkBTzjJCZvNk
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:41 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_ruby
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1074'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVkhoUFaInyAe
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffpwHGFkcia4E",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466398652,
+              "current_period_end": 1471669052,
+              "current_period_start": 1468990652,
+              "customer": "cus_8U1TcYRfvl8VqP",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "corporate_ruby",
+                "object": "plan",
+                "amount": 500000,
+                "created": 1453710393,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Ruby Membership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466398652,
+              "status": "past_due",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": true,
+          "total_count": 2,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:42 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_sapphire
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVkXAULtpAgjY
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:42 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=corporate_topaz
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1074'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVkiPR0OJmGBb
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffujqdnveuPZH",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466398957,
+              "current_period_end": 1471669357,
+              "current_period_start": 1468990957,
+              "customer": "cus_8ffUbWEM9gofdR",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "corporate_topaz",
+                "object": "plan",
+                "amount": 20000,
+                "created": 1453710394,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Topaz Membership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466398977,
+              "status": "active",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:42 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=friend
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVkyM31nSPlX2
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:42 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/subscriptions?include%5B%5D=total_count&limit=1&plan=individual
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.43.0
+      Authorization:
+      - Bearer sk_test_XtTL5T07vCobwN0oPCOqg6jZ
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.43.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin15","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Rey.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016;
+        root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64","hostname":"Rey.local"}'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 27 Jul 2016 03:28:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1072'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_8tVkpUfthpgcTy
+      Stripe-Version:
+      - '2015-04-07'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "sub_8ffdAZa04rNUwK",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "created": 1466397966,
+              "current_period_end": 1471668366,
+              "current_period_start": 1468989966,
+              "customer": "cus_8ff9KmLm6ZG9oW",
+              "discount": null,
+              "ended_at": null,
+              "livemode": false,
+              "metadata": {},
+              "plan": {
+                "id": "individual",
+                "object": "plan",
+                "amount": 4000,
+                "created": 1453710396,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "name": "Developer Membership",
+                "statement_descriptor": null,
+                "trial_period_days": null
+              },
+              "quantity": 1,
+              "start": 1466397966,
+              "status": "active",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/subscriptions"
+        }
+    http_version: 
+  recorded_at: Wed, 27 Jul 2016 03:28:42 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/stats_spec.rb
+++ b/spec/lib/stats_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Stats, :vcr do
       # revenue shall be:
       # individual $40 + Ruby $5,000 + Onyx $50 + $520 other individuals
       # = $5,610 per month
-      expect(response).to include("Projected monthly income is $5,610.00 per month")
+      expect(response).to include("Projected monthly income is $8,730.00 per month")
     end
   end
 
@@ -68,7 +68,7 @@ RSpec.describe Stats, :vcr do
   context "monthly_revenue_projection" do
     it "is accurate" do
       expect(subject.monthly_revenue_projection).to eq(
-        "1 Onyx Memberbership, 0 Emerald Memberberships, 0 Jade Memberberships, 1 Ruby Membership, 0 Sapphire Memberships, 0 Topaz Memberships, 0 Friends of Ruby Together, and 1 Developer Membership. Projected revenue now $5,610.00 per month."
+        "1 Onyx Memberbership, 0 Emerald Memberberships, 0 Jade Memberberships, 2 Ruby Memberships, 0 Sapphire Memberships, 1 Topaz Membership, 0 Friends of Ruby Together, and 1 Developer Membership. Projected revenue now $8,730.00 per month."
       )
     end
   end

--- a/spec/lib/stats_spec.rb
+++ b/spec/lib/stats_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe Stats, :vcr do
     it "is accurate" do
       response = subject.since(4.weeks.ago)
       expect(response).to be_present
-      expect(response).to include("1 new person")
-      expect(response).to include("2 new companies")
-      expect(response).to include("3 new members total")
-      # revenue shall be:
-      # individual $40 + Ruby $5,000 + Onyx $50 + $520 other individuals
-      # = $5,610 per month
-      expect(response).to include("Projected monthly income is $8,730.00 per month")
+      expect(response).to include("1 new person") # $40/month
+      expect(response).to include("2 new companies") # Ruby $5,000 + Onyx $50
+      expect(response).to include("3 new members total") # Total $5,090
+      # To match the data in our test Stripe environment:
+      # + 1 existing Ruby $5,000 + 1 existing Topaz $200 + $520 other individuals
+      # = $10,810 per month
+      expect(response).to include("Projected monthly income is $10,810.00 per month")
     end
   end
 
@@ -68,7 +68,7 @@ RSpec.describe Stats, :vcr do
   context "monthly_revenue_projection" do
     it "is accurate" do
       expect(subject.monthly_revenue_projection).to eq(
-        "1 Onyx Memberbership, 0 Emerald Memberberships, 0 Jade Memberberships, 2 Ruby Memberships, 0 Sapphire Memberships, 1 Topaz Membership, 0 Friends of Ruby Together, and 1 Developer Membership. Projected revenue now $8,730.00 per month."
+        "1 Onyx Memberbership, 0 Emerald Memberberships, 0 Jade Memberberships, 2 Ruby Memberships, 0 Sapphire Memberships, 1 Topaz Membership, 0 Friends of Ruby Together, and 1 Developer Membership. Projected revenue now $10,810.00 per month."
       )
     end
   end

--- a/spec/requests/stripe_events_spec.rb
+++ b/spec/requests/stripe_events_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Stripe webhooks", :vcr do
 
   describe "customer.subscription.created" do
     let(:message) {
-      "1 Onyx Memberbership, 0 Emerald Memberberships, 0 Jade Memberberships, 2 Ruby Memberships, 0 Sapphire Memberships, 1 Topaz Membership, 0 Friends of Ruby Together, and 1 Developer Membership. Projected revenue now $8,730.00 per month."
+      "1 Onyx Memberbership, 0 Emerald Memberberships, 0 Jade Memberberships, 2 Ruby Memberships, 0 Sapphire Memberships, 1 Topaz Membership, 0 Friends of Ruby Together, and 1 Developer Membership. Projected revenue now $10,810.00 per month."
     }
     let(:membership) { double(Membership) }
     let(:user) { double(User, membership: membership) }
@@ -76,7 +76,7 @@ RSpec.describe "Stripe webhooks", :vcr do
 
   describe "customer.subscription.destroyed" do
     let(:message) {
-      "1 Onyx Memberbership, 0 Emerald Memberberships, 0 Jade Memberberships, 2 Ruby Memberships, 0 Sapphire Memberships, 1 Topaz Membership, 0 Friends of Ruby Together, and 1 Developer Membership. Projected revenue now $8,730.00 per month."
+      "1 Onyx Memberbership, 0 Emerald Memberberships, 0 Jade Memberberships, 2 Ruby Memberships, 0 Sapphire Memberships, 1 Topaz Membership, 0 Friends of Ruby Together, and 1 Developer Membership. Projected revenue now $10,810.00 per month."
     }
 
     it "runs our hook" do

--- a/spec/requests/stripe_events_spec.rb
+++ b/spec/requests/stripe_events_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Stripe webhooks", :vcr do
 
   describe "customer.subscription.created" do
     let(:message) {
-      "1 Onyx Memberbership, 0 Emerald Memberberships, 0 Jade Memberberships, 2 Ruby Memberships, 0 Sapphire Memberships, 0 Topaz Memberships, 1 Friend of Ruby Together, and 3 Developer Memberships. Projected revenue now $10,700.00 per month."
+      "1 Onyx Memberbership, 0 Emerald Memberberships, 0 Jade Memberberships, 2 Ruby Memberships, 0 Sapphire Memberships, 1 Topaz Membership, 0 Friends of Ruby Together, and 1 Developer Membership. Projected revenue now $8,730.00 per month."
     }
     let(:membership) { double(Membership) }
     let(:user) { double(User, membership: membership) }
@@ -76,7 +76,7 @@ RSpec.describe "Stripe webhooks", :vcr do
 
   describe "customer.subscription.destroyed" do
     let(:message) {
-      "1 Onyx Memberbership, 0 Emerald Memberberships, 0 Jade Memberberships, 2 Ruby Memberships, 0 Sapphire Memberships, 0 Topaz Memberships, 0 Friends of Ruby Together, and 0 Developer Memberships. Projected revenue now $10,570.00 per month."
+      "1 Onyx Memberbership, 0 Emerald Memberberships, 0 Jade Memberberships, 2 Ruby Memberships, 0 Sapphire Memberships, 1 Topaz Membership, 0 Friends of Ruby Together, and 1 Developer Membership. Projected revenue now $8,730.00 per month."
     }
 
     it "runs our hook" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,4 +18,6 @@ RSpec.configure do |config|
 
   config.order = :random
   Kernel.srand config.seed
+
+  config.example_status_persistence_file_path = ".rspec_failures"
 end


### PR DESCRIPTION
Stripe said:

>On August 11th, 2016, we'll be returning 400s for any `/customers` request that includes the `subscription` filter for the duration of the day.
>
>On August 25th, 2016, when we fully deactivate the `subscription` filter on the `/customers` endpoint, these API calls will begin to error.

This removes that API call, and replaces it with a non-deprecated one.

It also adds support for us to force a specific Stripe API version on e.g. staging, to be sure that nothing will break when we update to a newer API version in production.