### PR TITLE
Attempt to recover delinquent payers

### DIFF
--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -9,6 +9,7 @@ class PaymentMailer < ApplicationMailer
   def delinquent(user)
     @name = user.name.presence || "there" # "Hi Alice," or "Hi there,"
     @token = user.generate_reset_password_token!
+    user.update_attribute :delinquent_notification_sent_at, Time.now
     mail to: user.email, subject: "Reactivate your Ruby Together subscription?"
   end
 

--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -6,4 +6,10 @@ class PaymentMailer < ApplicationMailer
     mail to: user.email, subject: "Your payment to Ruby Together failed."
   end
 
+  def delinquent(user)
+    @name = user.name.presence || "there" # "Hi Alice," or "Hi there,"
+    @token = user.generate_reset_password_token!
+    mail to: user.email, subject: "Reactivate your Ruby Together subscription?"
+  end
+
 end

--- a/app/views/payment_mailer/delinquent.html.erb
+++ b/app/views/payment_mailer/delinquent.html.erb
@@ -1,0 +1,29 @@
+<p class="lead">Hi <%= @name %>,</p>
+
+<p>
+  Thanks for being a member of Ruby Together! We really appreciate your support.
+</p>
+
+<p>
+  We just wanted to let you know that your Ruby Together payments failed a few
+  times, so Stripe automatically deactivated your subscription at some point.
+</p>
+
+<p>
+  If you're happy for us to reactivate your subscription then please just reply
+  to this email, to give us permission to do so, and we'll sort it out for you.
+</p>
+
+<p>
+  You can easily check whether your payment information is correct
+  <a href="<%= membership_url(token: @token) %>">using this link</a>.
+</p>
+
+<p>
+  We'd be delighted to have your support again!  It makes a big difference.
+</p>
+
+<p>
+  Thanks,<br>
+  Ruby Together
+</p>

--- a/app/views/payment_mailer/delinquent.text.erb
+++ b/app/views/payment_mailer/delinquent.text.erb
@@ -1,0 +1,17 @@
+Hi <%= @name %>,
+
+Thanks for being a member of Ruby Together! We really appreciate your support.
+
+We just wanted to let you know that your Ruby Together payments failed a few
+times, so Stripe automatically deactivated your subscription at some point.
+
+If you're happy for us to reactivate your subscription then please just reply
+to this email, to give us permission to do so, and we'll sort it out for you.
+
+You can easily check whether your payment information is correct using this link:
+<%= membership_url(token: @token) %>
+
+We'd be delighted to have your support again!  It makes a big difference.
+
+Thanks,
+Ruby Together

--- a/db/migrate/20160815025629_add_delinquent_notification_sent_at_to_users.rb
+++ b/db/migrate/20160815025629_add_delinquent_notification_sent_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddDelinquentNotificationSentAtToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :delinquent_notification_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150319045915) do
+ActiveRecord::Schema.define(version: 20160815025629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,12 +35,12 @@ ActiveRecord::Schema.define(version: 20150319045915) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                           default: "", null: false
+    t.string   "encrypted_password",              default: "", null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",                   default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20150319045915) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "stripe_id"
+    t.datetime "delinquent_notification_sent_at"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/lib/tasks/delinquents.rake
+++ b/lib/tasks/delinquents.rake
@@ -1,0 +1,11 @@
+namespace :delinquents do
+  desc "Email delinquent users (that haven't already been told) to let them know they are delinquent"
+  task :send_email do
+    require_relative "../../config/initializers/stripe"
+    delinquent_users = User.delinquent.never_notified_of_delinquency
+
+    delinquent_users.each do |user|
+      PaymentMailer.delinquent(user).deliver_later
+    end
+  end
+end

--- a/spec/mailers/payment_mailer_spec.rb
+++ b/spec/mailers/payment_mailer_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe PaymentMailer, type: :mailer do
+  describe "delinquent" do
+    let(:user) { User.new(email: "to@example.org") }
+    let(:mail) { PaymentMailer.delinquent(user) }
+
+    it "emails asking to reactivate" do
+      expect(mail.subject).to eq("Reactivate your Ruby Together subscription?")
+      expect(mail.to).to eq(["to@example.org"])
+      expect(mail.from).to eq(["hello@rubytogether.org"])
+      expect(mail.body.encoded).to include("Ruby Together payments failed a few")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,4 +10,18 @@ RSpec.describe User do
       expect(Stripe::Customer.retrieve("cus_7VmzGcohKDBG5L").email).to eq("bob@example.com")
     end
   end
+
+  describe ".never_notified_of_delinquency" do
+    let!(:alice) {
+      User.create! email: "alice@example.org", delinquent_notification_sent_at: Time.now
+    }
+    let!(:bob) {
+      User.create! email: "bob@example.org", delinquent_notification_sent_at: nil
+    }
+
+    it "only finds users who have never been notified" do
+      expect(User.never_notified_of_delinquency).to include(bob)
+      expect(User.never_notified_of_delinquency).not_to include(alice)
+    end
+  end
 end


### PR DESCRIPTION
To run this:

```
rake delinquents:send_email
```

WARNING: In production, this will send actual emails. To actual people.

After each person has been sent an email we record when that happened and (the rake task at least) won't send them another one next time we run it. Hopefully.