### PR TITLE
Preserve User record on signup failure

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -12,7 +12,6 @@ class MembershipsController < ApplicationController
 
     render json: {result: "success", url: redirect_url(kind) }
   rescue CreateMembership::Error => e
-    user.destroy if user.persisted?
     render_failure
   rescue => e
     Rollbar.error(e)


### PR DESCRIPTION
Destroying the User record also destroys the Customer record in Stripe,
which reduces our ability to investigate or debug failures after the
fact. There's also no harm (as far as I can tell) in keeping around the
User records for someone who tried to create a membership and failed. If
they successfully become a member later, it will reuse the
existing User record just fine.