### PR TITLE
Add more detail to README about deploying

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ Clone the repository and run `bin/setup`. Start a server with `bin/rails s`.
 
 ## deploying
 
-Deploy to staging by running `bin/staging push`. Deploy to production by running `bin/production push`.
+Deploy to staging manually by running `bin/staging push`.
+The `master` branch is deployed to staging automatically on merges.
+You can find the staging app here: https://rubytogether-staging.herokuapp.com
+
+Deploy to production by running `bin/production push`.
 
 ## contributing
 


### PR DESCRIPTION
Reason for Change
=================
* I wasn't clear where the staging app was being hosted.
* I was asking questions about deploys and now I'm putting the answers in the `README.md`.

Changes
=======
* Specify the location of the staging Heroku app.
* Note that `master` auto-deploys to staging.