### PR TITLE
Use "support" instead of "back"

### DIFF
--- a/app/views/home/_join.html.erb
+++ b/app/views/home/_join.html.erb
@@ -1,14 +1,14 @@
 <section class="group">
   <div class="join-box center">
     <p class="title">Developers</p>
-    <%= link_to "Back Ruby Together", developers_path(anchor: "plans"), class: "solid-button" %>
+    <%= link_to "Support Ruby Together", developers_path(anchor: "plans"), class: "solid-button" %>
     <p>From $10 per month</p>
     <p class="learn-more"><%= link_to "Learn More", developers_path %></p>
   </div>
 
   <div class="join-box center">
     <p class="title">Companies</p>
-    <%= link_to "Back Ruby Together", companies_path(anchor: "plans"), class: "solid-button" %>
+    <%= link_to "Support Ruby Together", companies_path(anchor: "plans"), class: "solid-button" %>
     <p>From $50 per month</p>
     <p class="learn-more"><%= link_to "Learn More", companies_path %></p>
   </div>


### PR DESCRIPTION
Reason for Change
=================
* I was confused when I saw this button. I thought it referred to the browser's "back" action.
* I wondered if this was confusing for anyone else, so I opened this PR.

Changes
=======
* Replace `Back Ruby Together` with `Support Ruby Together`.

![image](https://user-images.githubusercontent.com/913757/36511134-6eb12efa-171a-11e8-92e9-83eae7e361fa.png)


