### PR TITLE
Added disclaimer for infographic

### DIFF
--- a/app/views/home/_funding_levels.html.erb
+++ b/app/views/home/_funding_levels.html.erb
@@ -1,6 +1,10 @@
 <section>
   <h3>Fundraising Progress</h3>
-
+  
+    <p> 
+      This graph represents Ruby Together's fundraising progress to date, as well as our future fundraising goals. This does not include sponsored work on projects by groups other than Ruby Together.
+    </p>
+  
   <%= render "funding_progress_bar" %>
 
   <%= render "fundraising_goals" %>


### PR DESCRIPTION
Added a disclaimer underneath "Fundraising Progress" to clarify that the fundraising graph represents funds raised by Ruby Together and does *not* include the fundraising efforts of other groups.

See: https://github.com/rubytogether/rubytogether.org/issues/203 for more information.