### PR TITLE
Fix current paid work availability

### DIFF
--- a/db/cms_seeds/ruby-together/pages/index/team/content.html
+++ b/db/cms_seeds/ruby-together/pages/index/team/content.html
@@ -3,7 +3,7 @@ label: "The RubyGems Partnership"
 
 [wysiwyg content]
 <section class="group">
-  <p>Ruby Together funds up to 5 hours per week of ongoing work by a development team consisting of:</p>
+  <p>Ruby Together funds up to 8 hours per month of ongoing work by a development team consisting of:</p>
 
   <ul>
     <li><a href="https://twitter.com/sonalkr132">Aditya Prakash</a>, who also works to keep <a href="http://rubygems.org">RubyGems.org</a> up, improving the codebase and managing the servers.</li>


### PR DESCRIPTION
Unfortunately, RubyTogether's capacity has been greatly harmed lately. Hopefully we can get back to the previous situation soon, but until then we should be transparent about it.