### PR TITLE
Fixed typo on homepage

### DIFF
--- a/app/views/home/_progress_so_far.html.erb
+++ b/app/views/home/_progress_so_far.html.erb
@@ -1,7 +1,7 @@
 <section id="progress">
   <h3>Significant Progress</h3>
   <p>
-    For over six years, Ruby Together as maintained and developed infrastructure for the Ruby programming language:
+    For over six years, Ruby Together has maintained and developed infrastructure for the Ruby programming language:
   </p>
   <ul>
     <li>


### PR DESCRIPTION
Hi, just a tiny PR to add an "h" back to the homepage that got removed accidentally in a previous change!