### PR TITLE
Show underlines on links

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,14 +35,6 @@ section.group {
   margin-bottom: 1.75em;
 }
 
-a {
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
-}
-
 p.small {
   font-size: 0.75em;
 }


### PR DESCRIPTION
just a small css change :)

Specifically: I definitely didn't notice links were links until I was almost through this article!
https://rubytogether.org/news/2022-08-18-5-reasons-to-turn-that-idea-into-a-rubyconf-2022-talk

More generally: links should be underlined as a part of accessibility. Underlined links are also more likely to be noticed and used.. Here's one quick reference on the accessibility/usability of link underlining: https://www.usability.gov/get-involved/blog/2007/05/underlining-links.html


---

I didn't get to test this change -- `bin/setup` gave me some trouble with postgres